### PR TITLE
Add changelog update reminder to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,6 @@ Fixes #
 ## Summary of changes
 
 ## How to test
+
+## Checklist
+- [ ] I have updated the changelog (`CHANGELOG.md`)


### PR DESCRIPTION
Fixes #

## Summary of changes
This PR updates the pull request template to include a reminder to update the changelog for each PR.

## How to test
